### PR TITLE
clear failed translations in migration

### DIFF
--- a/site/gatsby-site/migrations/2025.10.07T12.00.00.delete-empty-translations.js
+++ b/site/gatsby-site/migrations/2025.10.07T12.00.00.delete-empty-translations.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  const db = client.db('translations');
+
+  const reportTranslations = db.collection('reports');
+
+  const reportResult = await reportTranslations.deleteMany({
+    title: '',
+  });
+
+  console.log(`Deleted ${reportResult.deletedCount} report empty translations`);
+
+  const incidentTranslations = db.collection('incidents');
+
+  const incidentResult = await incidentTranslations.deleteMany({
+    title: '',
+  });
+
+  console.log(`Deleted ${incidentResult.deletedCount} incident empty translations`);
+};


### PR DESCRIPTION
This copies https://github.com/smcgregor/aiid/blob/staging/site/gatsby-site/migrations/2025.09.09T12.00.00.delete-empty-translations.js without changes to resolve #3763